### PR TITLE
Replace deprecated 'go get' for installing dependencies with 'go install'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3
 
 RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh go"]
-RUN ["/bin/sh", "-c", "go get github.com/opencredo/terrahelp"]
+RUN ["/bin/sh", "-c", "go install github.com/opencredo/terrahelp@latest"]
 ENV PATH=$PATH:/root/go/bin/
 
 ENTRYPOINT ["/src/main.sh"]


### PR DESCRIPTION
Deprecation notice: https://go.dev/doc/go-get-install-deprecation